### PR TITLE
missing import, gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.pyc
+*~
+.ipynb_checkpoints

--- a/Demo.ipynb
+++ b/Demo.ipynb
@@ -927,7 +927,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "from IPython.display import Image, FileLink, SVG"
+      "from IPython.display import Image, FileLink, SVG, display"
      ],
      "language": "python",
      "metadata": {},


### PR DESCRIPTION
The demo notebook is missing the `display` import.

Also added `.gitignore` file.
